### PR TITLE
Fixes the issues with the buffers crashing

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/FlatBuffers.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/FlatBuffers.xcscheme
@@ -41,6 +41,8 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
+      enableAddressSanitizer = "YES"
+      enableASanStackUseAfterReturn = "YES"
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference

--- a/Sources/FlatBuffers/Constants.swift
+++ b/Sources/FlatBuffers/Constants.swift
@@ -5,47 +5,47 @@ import Foundation
 
 private let isLitteEndian = CFByteOrderGetCurrent() == Int(CFByteOrderLittleEndian.rawValue)
 
-protocol Scaler: Equatable {
-    associatedtype NumaricValue
-    var convertedEndian: NumaricValue { get }
+public protocol Scalar: Equatable {
+    associatedtype NumericValue
+    var convertedEndian: NumericValue { get }
 }
 
-extension Scaler where Self: FixedWidthInteger {
-    var convertedEndian: NumaricValue {
-        if isLitteEndian { return self as! Self.NumaricValue }
-        return self.littleEndian as! Self.NumaricValue
+extension Scalar where Self: FixedWidthInteger {
+    public var convertedEndian: NumericValue {
+        if isLitteEndian { return self as! Self.NumericValue }
+        return self.littleEndian as! Self.NumericValue
     }
 }
 
-extension Double: Scaler {
-    typealias NumaricValue = UInt64
+extension Double: Scalar {
+    public typealias NumericValue = UInt64
     
-    var convertedEndian: UInt64 {
+    public var convertedEndian: UInt64 {
         if isLitteEndian { return self.bitPattern }
         return self.bitPattern.littleEndian
     }
 }
-extension Float: Scaler {
-    typealias NumaricValue = UInt32
+extension Float: Scalar {
+    public typealias NumericValue = UInt32
     
-    var convertedEndian: UInt32 {
+    public var convertedEndian: UInt32 {
         if isLitteEndian { return self.bitPattern }
         return self.bitPattern.littleEndian
     }
 }
 
-extension Int: Scaler { typealias NumaricValue = Int }
+extension Int: Scalar { public typealias NumericValue = Int }
 
-extension Int8: Scaler { typealias NumaricValue = Int8 }
-extension Int16: Scaler { typealias NumaricValue = Int16 }
-extension Int32: Scaler { typealias NumaricValue = Int32 }
-extension Int64: Scaler { typealias NumaricValue = Int64 }
+extension Int8: Scalar { public typealias NumericValue = Int8 }
+extension Int16: Scalar { public typealias NumericValue = Int16 }
+extension Int32: Scalar { public typealias NumericValue = Int32 }
+extension Int64: Scalar { public typealias NumericValue = Int64 }
 
-extension UInt8: Scaler { typealias NumaricValue = UInt8 }
-extension UInt16: Scaler { typealias NumaricValue = UInt16 }
+extension UInt8: Scalar { public typealias NumericValue = UInt8 }
+extension UInt16: Scalar { public typealias NumericValue = UInt16 }
 
-extension UInt32: Scaler { typealias NumaricValue = UInt32 }
-extension UInt64: Scaler { typealias NumaricValue = UInt64 }
+extension UInt32: Scalar { public typealias NumericValue = UInt32 }
+extension UInt64: Scalar { public typealias NumericValue = UInt64 }
 
 public typealias UOffset = UInt32
 public typealias SOffset = Int32

--- a/Sources/FlatBuffers/Offset.swift
+++ b/Sources/FlatBuffers/Offset.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-struct Offset<T> {
-    var o: UOffset
-    var isNull: Bool { return o == nil }
-    init(offset: UOffset) { o = offset }
-    init() { o = 0 }
+public struct Offset<T> {
+    public var o: UOffset
+    public var isNull: Bool { return o == nil }
+    public init(offset: UOffset) { o = offset }
+    public init() { o = 0 }
 }

--- a/Sources/FlatBuffers/Table.swift
+++ b/Sources/FlatBuffers/Table.swift
@@ -23,7 +23,7 @@ class Table {
         return index < _bb.read(def: VOffset.self, position: Int(index), with: size) ? Int32(_bb.read(def: VOffset.self, position: Int(o + index), with: size)) : 0
     }
     
-    func reader<T: Scaler>(def: T, position: Int) -> T {
+    func reader<T: Scalar>(def: T, position: Int) -> T {
         let r = _bb.read(def: T.self, position: position, with: MemoryLayout<T>.stride)
         return r
     }

--- a/Tests/FlatBuffersTests/FlatbuffersDoubleTests.swift
+++ b/Tests/FlatBuffersTests/FlatbuffersDoubleTests.swift
@@ -4,19 +4,12 @@ import XCTest
 final class FlatBuffersDoubleTests: XCTestCase {
 
     let country = "Norway"
-    
-    func testEndian() { print("endian test: ", CFByteOrderGetCurrent() == Int(CFByteOrderLittleEndian.rawValue)) }
-    
-    func testBuilderInit() {
-        XCTAssertNotNil(FlatBuffersBuilder(initialSize: 1))
-    }
   
     func testCreateCountry() {
         var b = FlatBuffersBuilder(initialSize: 16)
         _ = CountryDouble.createCountry(builder: &b, name: country, log: 200, lan: 100)
-        let v: [UInt8] = [10, 0, 28, 0, 4, 0, 8, 0, 16, 0, 10, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 89, 64, 0, 0, 0, 0, 0, 0, 105, 64, 0, 0, 0, 0, 6, 0, 0, 0, 78, 111, 114, 119, 97, 121, 0, 0,]
+        let v: [UInt8] = [10, 0, 28, 0, 4, 0, 8, 0, 16, 0, 10, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 89, 64, 0, 0, 0, 0, 0, 0, 105, 64, 0, 0, 0, 0, 6, 0, 0, 0, 78, 111, 114, 119, 97, 121, 0, 0]
         XCTAssertEqual(b.sizedArray, v)
-        b.clear()
     }
     
     func testCreateFinish() {
@@ -34,17 +27,9 @@ final class FlatBuffersDoubleTests: XCTestCase {
         let v: [UInt8] = [60, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 28, 0, 4, 0, 8, 0, 16, 0, 10, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 89, 64, 0, 0, 0, 0, 0, 0, 105, 64, 0, 0, 0, 0, 6, 0, 0, 0, 78, 111, 114, 119, 97, 121, 0, 0]
         XCTAssertEqual(b.sizedArray, v)
     }
-
-    func testFetchLan() {
-        let bb: [UInt8] = [16, 0, 0, 0, 0, 0, 10, 0, 28, 0, 4, 0, 8, 0, 16, 0, 10, 0, 0, 0, 24, 0, 0, 0, 0, 0, 0, 0, 0, 0, 89, 64, 0, 0, 0, 0, 0, 0, 105, 64, 0, 0, 0, 0, 6, 0, 0, 0, 78, 111, 114, 119, 97, 121, 0, 0]
-        var b = FlatBuffer(bytes: bb)
-        let country = CountryDouble.getRootAsCountry(b)
-        XCTAssertEqual(100.0, country.lan)
-        b.clear()
-    }
 }
 
-struct CountryDouble {
+class CountryDouble {
     
     static let offsets: (name: VOffset, lan: VOffset, lng: VOffset) = (4,6,8)
     


### PR DESCRIPTION
The following PR fixes the issue that we have been facing regarding the memory management and deallocation. we fixed this by moving the logic from writing using pointers into writing using `storeBytes`. I read the logic that you implemented in the following [repository](https://github.com/mzaks/FlatBuffersSwift) when creating the strings, and moved the entire logic to use the same function storeBytes since that seemed to solve the issue with the crashes and memory allocation

Fixes #15 and Closes #16 and Closes #17